### PR TITLE
Implement search filters

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -57,6 +57,11 @@ app.add_middleware(
 class SearchRequest(BaseModel):
     prompt: str
     size: int = 20
+    artist: Optional[str] = None
+    album: Optional[str] = None
+    song_type: Optional[str] = None
+    release_from: Optional[str] = None
+    release_to: Optional[str] = None
 
 class SongResult(BaseModel):
     title: str
@@ -80,7 +85,15 @@ def health():
 @app.post("/search", response_model=List[SongResult], summary="Hybrid search")
 def api_search(req: SearchRequest):
     try:
-        hits = hybrid_search(req.prompt, req.size)
+        hits = hybrid_search(
+            req.prompt,
+            req.size,
+            artist=req.artist,
+            album=req.album,
+            song_type=req.song_type,
+            release_from=req.release_from,
+            release_to=req.release_to,
+        )
     except Exception as e:
         print(f"Unhandled exception in hybrid_search: {type(e).__name__} - {e}")
         raise HTTPException(status_code=500, detail=f"Search backend error: {str(e)}")

--- a/app/scripts/build_songs_index.py
+++ b/app/scripts/build_songs_index.py
@@ -59,6 +59,8 @@ def load_data_from_db() -> pd.DataFrame:
             s.artists AS s_artists,
             s.popularity,
             s.song_type,
+            s.album_name,
+            s.release_date,
             l.lyrics,
             e.embedding,
             ar.artist_id,
@@ -140,6 +142,8 @@ def create_index(es: Elasticsearch, index_name: str, dims: int):
                 "lyrics": {"type": "text", "analyzer": "standard"},
                 "popularity": {"type": "integer"},
                 "song_type": {"type": "keyword"},
+                "album_name": {"type": "text", "analyzer": "standard"},
+                "release_date": {"type": "date"},
                 # Artist related fields from 'artists' table
                 "artist_id": {"type": "keyword"}, # from artists.artist_id
                 "name_artists": {"type": "text", "analyzer": "standard"}, # from artists.name
@@ -158,7 +162,6 @@ def create_index(es: Elasticsearch, index_name: str, dims: int):
                 # "track_number": {"type": "integer"},
                 # "num_artists": {"type": "integer"},
                 # "num_available_markets": {"type": "integer"},
-                # "release_date": {"type": "date"},
                 # "duration_ms": {"type": "integer"},
                 # "key": {"type": "integer"},
                 # "mode": {"type": "integer"},
@@ -196,6 +199,8 @@ def bulk_load(es: Elasticsearch, index_name: str, df: pd.DataFrame):
             "lyrics": r.lyrics,
             "popularity": None if pd.isna(r.popularity) else int(r.popularity),
             "song_type": r.song_type,
+            "album_name": r.album_name,
+            "release_date": r.release_date,
             "artist_id": r.artist_id, # from artists table
             "name_artists": r.name_artists, # from artists table
             "artist_type": r.artist_type,
@@ -205,7 +210,19 @@ def bulk_load(es: Elasticsearch, index_name: str, df: pd.DataFrame):
             "embedding": r.embedding,
         }
         # Clean NaN/None for text fields to avoid issues with ES
-        for key in ["song_name", "lyrics", "song_type", "artist_id", "name_artists", "artist_type", "main_genre", "genres", "image_url"]:
+        for key in [
+            "song_name",
+            "lyrics",
+            "song_type",
+            "album_name",
+            "release_date",
+            "artist_id",
+            "name_artists",
+            "artist_type",
+            "main_genre",
+            "genres",
+            "image_url",
+        ]:
             if pd.isna(source_doc.get(key)):
                 source_doc[key] = None # Or "" if you prefer empty string
 


### PR DESCRIPTION
## Summary
- extend search request model to include artist, album, song_type and release date filters
- add optional filters in `/search` endpoint
- implement filter logic in the Elasticsearch query
- include album and release date data in indexing script and mapping

## Testing
- `python -m py_compile app/main.py app/services/search.py app/scripts/build_songs_index.py`

------
https://chatgpt.com/codex/tasks/task_e_685d96fd59cc832a8a1c75f942265265