### PR TITLE
Make Elasticsearch index configurable

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -93,7 +93,7 @@ def api_search(req: SearchRequest):
                 "release_date": req.release_date,
             }.items() if v
         }
-        hits = hybrid_search(req.prompt, req.size, filters)
+        hits = hybrid_search(req.prompt, req.size, filters, ES_INDEX)
     except Exception as e:
         print(f"Unhandled exception in hybrid_search: {type(e).__name__} - {e}")
         raise HTTPException(status_code=500, detail=f"Search backend error: {str(e)}")

--- a/app/services/search.py
+++ b/app/services/search.py
@@ -5,6 +5,8 @@ import os, json
 from elasticsearch import Elasticsearch
 from openai import OpenAI
 
+ES_INDEX = os.getenv("ELASTICSEARCH_INDEX", "songs")
+
 ES = Elasticsearch(os.getenv("ELASTICSEARCH_HOST", "http://elasticsearch:9200"))
 EMB_MODEL = "text-embedding-3-small"  # 1536-dimensional embedding
 
@@ -36,7 +38,7 @@ def keyword_expand(prompt: str) -> List[str]:
     return [str(k).strip() for k in raw if str(k).strip()]
 
 
-def search(prompt: str, size: int = 20, filters: Optional[Dict[str, str]] = None):
+def search(prompt: str, size: int = 20, filters: Optional[Dict[str, str]] = None, es_index: str = ES_INDEX):
     vec = embed(prompt)
     kws = keyword_expand(prompt)
 
@@ -86,5 +88,5 @@ def search(prompt: str, size: int = 20, filters: Optional[Dict[str, str]] = None
             }
         }
     }
-    res = ES.search(index="songs", body=es_query)
+    res = ES.search(index=es_index, body=es_query)
     return res["hits"]["hits"]


### PR DESCRIPTION
## Summary
- make index name configurable for searches
- use environment variable `ELASTICSEARCH_INDEX`

## Testing
- `python -m py_compile app/services/search.py`
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6865ff0070d8832a89dbece0653db28c