### PR TITLE
Update song index SQL to use releases table

### DIFF
--- a/app/scripts/build_songs_index.py
+++ b/app/scripts/build_songs_index.py
@@ -64,7 +64,7 @@ def load_data_from_db() -> pd.DataFrame:
             ar.genres,
             ar.image_url,
             a.name AS album_name,
-            a.release_date,
+            r.release_date,
             sl.spotify_url,
             sl.youtube_music_url,
             sl.apple_music_url
@@ -80,6 +80,8 @@ def load_data_from_db() -> pd.DataFrame:
             tracks t ON s.song_id = t.song_id
         LEFT JOIN
             albums a ON t.album_id = a.album_id
+        LEFT JOIN
+            releases r ON r.album_id = a.album_id
         LEFT JOIN
             melodymind_song_links sl ON s.song_id = sl.song_id;
         """


### PR DESCRIPTION
## Summary
- fetch release dates from `releases` table when building the songs index

## Testing
- `python app/scripts/build_songs_index.py --es-url http://localhost:9200 --es-index test_index` *(fails: Failed to connect to Elasticsearch)*

------
https://chatgpt.com/codex/tasks/task_e_686d6dec4fc8832a86e3040dba8c64db