### PR TITLE
Add song_name search filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,16 @@ Once everything is running, test the API:
 
 visit `http://localhost:5051/docs` in your browser to use the Swagger UI.
 
+The `/search` endpoint accepts optional filters in the request body:
+
+- `song_name`
+- `artist_name`
+- `album_name`
+- `song_type`
+- `release_date`
+
+These fields let you narrow results by song details in addition to the text prompt.
+
 
 ## MySQL Tips
 

--- a/app/main.py
+++ b/app/main.py
@@ -57,6 +57,7 @@ app.add_middleware(
 class SearchRequest(BaseModel):
     prompt: str
     size: int = 20
+    song_name: Optional[str] = None
     artist_name: Optional[str] = None
     album_name: Optional[str] = None
     song_type: Optional[str] = None
@@ -87,6 +88,7 @@ def api_search(req: SearchRequest):
     try:
         filters = {
             k: v for k, v in {
+                "song_name": req.song_name,
                 "artist_name": req.artist_name,
                 "album_name": req.album_name,
                 "song_type": req.song_type,

--- a/app/services/search.py
+++ b/app/services/search.py
@@ -44,6 +44,8 @@ def search(prompt: str, size: int = 20, filters: Optional[Dict[str, str]] = None
 
     filter_clauses = []
     if filters:
+        if song_name := filters.get("song_name"):
+            filter_clauses.append({"match": {"song_name": song_name}})
         if artist := filters.get("artist_name"):
             filter_clauses.append({"match": {"name_artists": artist}})
         if album := filters.get("album_name"):


### PR DESCRIPTION
## Summary
- support optional `song_name` filter in the search API
- include new filter in search service logic
- document all available search filters in README

## Testing
- `python -m py_compile app/main.py app/services/search.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68701b518414832aaa2f79ea5ccc588c